### PR TITLE
Use LDLIBS instead of LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ remfmt.o
 
 CPPFLAGS := -D_DEFAULT_SOURCE -D_FILE_OFFSET_BITS=64
 CFLAGS   := -O0 -g -std=c99 -Wall -I. -Ideps/cJSON -Ideps/struct/include/struct
-LDFLAGS  := -lm
+LDLIBS  := -lm
 
 all: remfs remfmt
 
-remfs: LDFLAGS+= -lfuse
+remfs: LDLIBS += -lfuse
 remfs: main.o $(OBJ)
 
 remfmt: remfmt_cli.o $(OBJ)


### PR DESCRIPTION
Thanks for making this project, it's really cool!

On my machine, compilation was failing because the arguments to `cc` were in the wrong order. It [seems like](https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html) `LDLIBS` is the right spot to specify libraries.